### PR TITLE
Refactor McpInstallButton to use Docusaurus/Infima styling

### DIFF
--- a/src/types/docusaurus.d.ts
+++ b/src/types/docusaurus.d.ts
@@ -3,6 +3,16 @@
  * These modules are provided by Docusaurus at runtime via webpack aliases.
  */
 
+declare module '@theme/Icon/Copy' {
+  import type { ComponentProps } from 'react';
+  export default function IconCopy(props: ComponentProps<'svg'>): JSX.Element;
+}
+
+declare module '@theme/Icon/Success' {
+  import type { ComponentProps } from 'react';
+  export default function IconSuccess(props: ComponentProps<'svg'>): JSX.Element;
+}
+
 declare module '@docusaurus/useGlobalData' {
   /**
    * Hook to get all global data from all plugins.

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -14,5 +14,10 @@ export default defineConfig({
   splitting: false,
   treeshake: true,
   outDir: 'dist',
-  external: ['react', 'react-dom', '@docusaurus/useGlobalData'],
+  external: [
+    'react',
+    'react-dom',
+    '@docusaurus/useGlobalData',
+    /^@theme\//, // Docusaurus theme aliases resolved at runtime
+  ],
 });


### PR DESCRIPTION
## Summary
- Replace inline styles with Infima CSS classes (dropdown, button--primary, badge--success)
- Use Docusaurus theme icons (@theme/Icon/Copy, @theme/Icon/Success) instead of custom SVGs
- Add MCP logo icon and "Install docs MCP" default label
- Sort MCP clients alphabetically by display name
- Use CSS variables for easy theming customization

## Test plan
- [x] Verify dropdown opens and closes correctly
- [x] Verify button uses theme primary color
- [x] Verify clients are sorted alphabetically
- [x] Verify copy button works and shows success state
- [x] Test in both light and dark modes
- [x] Verify code blocks have consistent dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)