### PR TITLE
fix: restore default export for Docusaurus plugin compatibility

### DIFF
--- a/examples/basic-docs/src/theme/NavbarItem/McpInstallNavbarItem.js
+++ b/examples/basic-docs/src/theme/NavbarItem/McpInstallNavbarItem.js
@@ -2,5 +2,12 @@ import React from 'react';
 import { McpInstallButton } from 'docusaurus-plugin-mcp-server/theme';
 
 export default function McpInstallNavbarItem() {
-  return <McpInstallButton serverUrl="https://example.com/mcp" serverName="example-docs" />;
+  // Icon-only mode (no label) with custom header text
+  return (
+    <McpInstallButton
+      serverUrl="https://example.com/mcp"
+      serverName="example-docs"
+      headerText="Install in your AI tool:"
+    />
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// Default export for Docusaurus plugin loading (requires default export)
+export { default } from './plugin/docusaurus-plugin.js';
+// Named export for explicit imports
 export { default as mcpServerPlugin } from './plugin/docusaurus-plugin.js';
 export { McpDocsServer } from './mcp/server.js';
 


### PR DESCRIPTION
## Summary
- Restores the default export in `src/index.ts` which is required for Docusaurus plugin loading
- Updates the example to demonstrate icon-only mode with custom header text for McpInstallButton

## Problem
Docusaurus requires plugins to have a default export. This was removed in a previous commit but caused plugin loading to fail with:
```
normalizedPluginConfig.plugin is not a function
```

## Test plan
- [ ] Run `npm run build` and verify no errors
- [ ] Run the example site and verify McpInstallButton renders correctly
- [ ] Verify icon-only mode works (no label prop)
- [ ] Verify custom header text displays in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)