### PR TITLE
fix: add default export conditions for broader compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,18 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./adapters": {
       "types": "./dist/adapters-entry.d.ts",
-      "import": "./dist/adapters-entry.js"
+      "import": "./dist/adapters-entry.js",
+      "default": "./dist/adapters-entry.js"
     },
     "./theme": {
       "types": "./dist/theme/index.d.ts",
-      "import": "./dist/theme/index.js"
+      "import": "./dist/theme/index.js",
+      "default": "./dist/theme/index.js"
     }
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Add `"default"` export condition to all three export paths (`.`, `./adapters`, `./theme`)
- Ensures compatibility with bundlers and environments that don't explicitly handle the `"import"` condition

## Test plan
- [x] Verify package imports work in various bundlers (webpack, esbuild, vite)
- [x] Test that Docusaurus plugin loading still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)