### PR TITLE
feat: support server instructions and custom tool descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,26 @@ For the runtime adapters:
 | `name` | `string` | Yes | Server name |
 | `version` | `string` | No | Server version |
 | `baseUrl` | `string` | No | Base URL for full page URLs in responses |
+| `instructions` | `string` | No | Instructions describing how to use the server, surfaced to MCP clients in the `initialize` response |
+| `tools` | `object` | No | Per-tool overrides. Supports `docs_search.description` and `docs_fetch.description` to customize tool descriptions |
 
 *Use either file paths (Node.js) or pre-loaded data (Workers).
+
+Example with extended configuration:
+
+```javascript
+export default createVercelHandler({
+  docsPath: path.join(__dirname, '../build/mcp/docs.json'),
+  indexPath: path.join(__dirname, '../build/mcp/search-index.json'),
+  name: 'my-docs',
+  baseUrl: 'https://docs.example.com',
+  instructions: 'Search the Acme product docs. Use docs_search to find pages, then docs_fetch for full content.',
+  tools: {
+    docs_search: { description: 'Search the Acme product documentation.' },
+    docs_fetch: { description: 'Fetch the full markdown of an Acme docs page.' },
+  },
+});
+```
 
 ## Verifying Your Build
 

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -25,23 +25,17 @@
  */
 
 import { McpDocsServer } from '../mcp/server.js';
-import type { ProcessedDoc, McpServerDataConfig } from '../types/index.js';
+import type { ProcessedDoc, McpServerBaseConfig, McpServerDataConfig } from '../types/index.js';
 import { getCorsHeaders } from './cors.js';
 
 /**
  * Config for Cloudflare Workers adapter
  */
-export interface CloudflareAdapterConfig {
+export interface CloudflareAdapterConfig extends McpServerBaseConfig {
   /** Pre-loaded docs data (imported from docs.json) */
   docs: Record<string, ProcessedDoc>;
   /** Pre-loaded search index data (imported from search-index.json) */
   searchIndexData: Record<string, unknown>;
-  /** Server name */
-  name: string;
-  /** Server version */
-  version?: string;
-  /** Base URL for constructing full page URLs */
-  baseUrl?: string;
   /** CORS origin to allow. Defaults to '*' (all origins). */
   corsOrigin?: string;
 }
@@ -54,19 +48,11 @@ export interface CloudflareAdapterConfig {
  */
 export function createCloudflareHandler(config: CloudflareAdapterConfig) {
   let server: McpDocsServer | null = null;
-  const { corsOrigin, ...rest } = config;
-
-  const serverConfig: McpServerDataConfig = {
-    docs: rest.docs,
-    searchIndexData: rest.searchIndexData,
-    name: rest.name,
-    version: rest.version,
-    baseUrl: rest.baseUrl,
-  };
+  const { corsOrigin, ...serverConfig } = config;
 
   function getServer(): McpDocsServer {
     if (!server) {
-      server = new McpDocsServer(serverConfig);
+      server = new McpDocsServer(serverConfig satisfies McpServerDataConfig);
     }
     return server;
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -69,6 +69,7 @@ export class McpDocsServer {
         capabilities: {
           tools: {},
         },
+        instructions: this.config.instructions,
       }
     );
 
@@ -80,11 +81,13 @@ export class McpDocsServer {
    * Register all MCP tools using definitions from tool files
    */
   private registerTools(server: McpServer): void {
+    const toolOverrides = this.config.tools;
+
     // Register docs_search tool
     server.registerTool(
       docsSearchTool.name,
       {
-        description: docsSearchTool.description,
+        description: toolOverrides?.docs_search?.description ?? docsSearchTool.description,
         inputSchema: docsSearchTool.inputSchema,
       },
       async ({ query, limit }) => {
@@ -119,7 +122,7 @@ export class McpDocsServer {
     server.registerTool(
       docsFetchTool.name,
       {
-        description: docsFetchTool.description,
+        description: toolOverrides?.docs_fetch?.description ?? docsFetchTool.description,
         inputSchema: docsFetchTool.inputSchema,
       },
       async ({ url }) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -144,13 +144,27 @@ export interface McpManifest {
 }
 
 /**
- * MCP Server configuration for file-based loading
+ * Per-tool configuration overrides
  */
-export interface McpServerFileConfig {
-  /** Path to docs.json file */
-  docsPath: string;
-  /** Path to search-index.json file */
-  indexPath: string;
+export interface McpToolConfig {
+  /** Override the default tool description shown to MCP clients */
+  description?: string;
+}
+
+/**
+ * Overrides for the built-in MCP tools, keyed by tool name
+ */
+export interface McpServerToolsConfig {
+  /** Overrides for the docs_search tool */
+  docs_search?: McpToolConfig;
+  /** Overrides for the docs_fetch tool */
+  docs_fetch?: McpToolConfig;
+}
+
+/**
+ * Common MCP server configuration shared by all loading modes
+ */
+export interface McpServerBaseConfig {
   /** Server name */
   name: string;
   /** Server version */
@@ -159,24 +173,33 @@ export interface McpServerFileConfig {
   baseUrl?: string;
   /** Search provider module. Default: 'flexsearch' */
   search?: string;
+  /**
+   * Instructions describing how to use the server and its tools.
+   * Surfaced to MCP clients in the initialize response.
+   */
+  instructions?: string;
+  /** Per-tool overrides, such as custom descriptions */
+  tools?: McpServerToolsConfig;
+}
+
+/**
+ * MCP Server configuration for file-based loading
+ */
+export interface McpServerFileConfig extends McpServerBaseConfig {
+  /** Path to docs.json file */
+  docsPath: string;
+  /** Path to search-index.json file */
+  indexPath: string;
 }
 
 /**
  * MCP Server configuration for pre-loaded data (e.g., Cloudflare Workers)
  */
-export interface McpServerDataConfig {
+export interface McpServerDataConfig extends McpServerBaseConfig {
   /** Pre-loaded docs data */
   docs: Record<string, ProcessedDoc>;
   /** Pre-loaded search index data (exported from FlexSearch via exportSearchIndex) */
   searchIndexData: Record<string, unknown>;
-  /** Server name */
-  name: string;
-  /** Server version */
-  version?: string;
-  /** Base URL for constructing full page URLs (e.g., https://docs.example.com) */
-  baseUrl?: string;
-  /** Search provider module. Default: 'flexsearch' */
-  search?: string;
 }
 
 /**

--- a/tests/server-test.ts
+++ b/tests/server-test.ts
@@ -39,6 +39,35 @@ async function buildArtifacts() {
   return indexer.finalize();
 }
 
+/**
+ * Send a JSON-RPC request through the server's public Web Standard path
+ * and return the parsed JSON-RPC result.
+ */
+async function callMcp(
+  server: McpDocsServer,
+  method: string,
+  params: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const request = new Request('https://localhost/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+
+  const response = await server.handleWebRequest(request);
+  const body = (await response.json()) as { result?: Record<string, unknown> };
+  return body.result ?? {};
+}
+
+const initializeParams = {
+  protocolVersion: '2025-06-18',
+  capabilities: {},
+  clientInfo: { name: 'test-client', version: '1.0.0' },
+};
+
 describe('McpDocsServer', () => {
   let artifacts: Map<string, unknown>;
   let dataConfig: McpServerDataConfig;
@@ -118,6 +147,79 @@ describe('McpDocsServer', () => {
 
       expect(status.initialized).toBe(false);
       expect(status.docCount).toBe(0);
+    });
+  });
+
+  describe('instructions', () => {
+    it('surfaces configured instructions in the initialize result', async () => {
+      const server = new McpDocsServer({
+        ...dataConfig,
+        instructions: 'Use docs_search first, then docs_fetch for full content.',
+      });
+
+      const result = await callMcp(server, 'initialize', initializeParams);
+
+      expect(result.instructions).toBe('Use docs_search first, then docs_fetch for full content.');
+    });
+
+    it('omits instructions when not configured', async () => {
+      const server = new McpDocsServer(dataConfig);
+
+      const result = await callMcp(server, 'initialize', initializeParams);
+
+      expect(result.instructions).toBeUndefined();
+    });
+  });
+
+  describe('tool description overrides', () => {
+    it('applies custom descriptions to both tools', async () => {
+      const server = new McpDocsServer({
+        ...dataConfig,
+        tools: {
+          docs_search: { description: 'Custom search description' },
+          docs_fetch: { description: 'Custom fetch description' },
+        },
+      });
+
+      const result = await callMcp(server, 'tools/list', {});
+      const tools = result.tools as Array<{ name: string; description: string }>;
+
+      const search = tools.find((t) => t.name === 'docs_search');
+      const fetch = tools.find((t) => t.name === 'docs_fetch');
+
+      expect(search?.description).toBe('Custom search description');
+      expect(fetch?.description).toBe('Custom fetch description');
+    });
+
+    it('falls back to default descriptions when not overridden', async () => {
+      const server = new McpDocsServer(dataConfig);
+
+      const result = await callMcp(server, 'tools/list', {});
+      const tools = result.tools as Array<{ name: string; description: string }>;
+
+      const search = tools.find((t) => t.name === 'docs_search');
+      const fetch = tools.find((t) => t.name === 'docs_fetch');
+
+      expect(search?.description).toContain('Search the documentation');
+      expect(fetch?.description).toContain('Fetch the complete content');
+    });
+
+    it('overrides only the specified tool, leaving the other default', async () => {
+      const server = new McpDocsServer({
+        ...dataConfig,
+        tools: {
+          docs_search: { description: 'Only search is custom' },
+        },
+      });
+
+      const result = await callMcp(server, 'tools/list', {});
+      const tools = result.tools as Array<{ name: string; description: string }>;
+
+      const search = tools.find((t) => t.name === 'docs_search');
+      const fetch = tools.find((t) => t.name === 'docs_fetch');
+
+      expect(search?.description).toBe('Only search is custom');
+      expect(fetch?.description).toContain('Fetch the complete content');
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves #58. Adds extended configuration for the runtime MCP server so consumers can customize how the server presents itself to AI clients, without forking the adapters.

Two new optional, backward-compatible config fields:

| Field | Description |
|-------|-------------|
| `instructions` | Forwarded to the MCP SDK `ServerOptions`; surfaced to clients in the `initialize` response. |
| `tools` | Per-tool overrides — `docs_search.description` and `docs_fetch.description` — applied at tool registration, falling back to the built-in defaults. |

## Changes

- **`src/types/index.ts`** — Extracted a shared `McpServerBaseConfig` (removing the field duplication between the file and data configs) and added `instructions` + `tools` (`McpServerToolsConfig` / `McpToolConfig`).
- **`src/mcp/server.ts`** — Forward `config.instructions` into the `McpServer` constructor; apply per-tool description overrides with `?? default` fallback.
- **`src/adapters/cloudflare.ts`** — Now spreads config through (`...serverConfig satisfies McpServerDataConfig`) and extends the shared base, so new base fields pass through automatically instead of being silently dropped by hand-mapping. Vercel/Netlify/Node already spread config and needed no change.
- **`README.md`** — Documented both options with an example.

## Testing

- Added 5 unit tests driving the public `handleWebRequest` path with real `initialize`/`tools/list` JSON-RPC calls (instructions present/absent, both overrides, default fallback, partial override).
- `npm run lint`, `npm run typecheck`, **69 unit tests**, and `snippets:check` all pass.
- Verified end-to-end on both SDK transports (Web Standard via tests; Node/HTTP via a throwaway script against the built `dist`).

Note: `npm run test:mcp` (Playwright) times out at `webServer` startup in my local sandbox; this reproduces on a clean `main` and the server boots/serves fine manually, so it appears environmental rather than related to this change. Worth a CI run to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)