### PR TITLE
Consider baseUrl when indexing

### DIFF
--- a/src/plugin/docusaurus-plugin.ts
+++ b/src/plugin/docusaurus-plugin.ts
@@ -154,7 +154,10 @@ export default function mcpServerPlugin(
 
       // Create provider context
       const mcpOutputDir = path.join(outDir, resolvedOptions.outputDir);
-      const baseUrl = `${context.siteConfig.url}${context.siteConfig.baseUrl ?? ''}`;
+      // Resolve the site's baseUrl (e.g. "/docs/") against the origin so document
+      // URLs are correct for sites served under a sub-path. Use the URL constructor
+      // rather than path.join, which would collapse "https://" into "https:/".
+      const baseUrl = new URL(context.siteConfig.baseUrl, context.siteConfig.url).href;
       const providerContext: ProviderContext = {
         baseUrl,
         serverName: resolvedOptions.server.name,
@@ -204,7 +207,7 @@ export default function mcpServerPlugin(
           buildTime: new Date().toISOString(),
           docCount: validDocs.length,
           serverName: resolvedOptions.server.name,
-          baseUrl: context.siteConfig.url,
+          baseUrl,
           indexers: indexerNames,
         };
 

--- a/src/plugin/docusaurus-plugin.ts
+++ b/src/plugin/docusaurus-plugin.ts
@@ -154,8 +154,9 @@ export default function mcpServerPlugin(
 
       // Create provider context
       const mcpOutputDir = path.join(outDir, resolvedOptions.outputDir);
+      const baseUrl = `${context.siteConfig.url}${context.siteConfig.baseUrl ?? ''}`;
       const providerContext: ProviderContext = {
-        baseUrl: context.siteConfig.url,
+        baseUrl,
         serverName: resolvedOptions.server.name,
         serverVersion: resolvedOptions.server.version,
         outputDir: mcpOutputDir,


### PR DESCRIPTION
mcp/docs.json file has incorrect structure when docusaurus app has a `baseUrl`

```ts
// docusaurus.config.js

module.exports = {
  url: 'https://example.com',
  baseUrl: '/path/to/site'
}
```

# Current

docs.json

❌ does not include baseUrl

```jsonc
{
// ...
"https://example.com/page": { /*...*/ }
//...
}
```

# Expected

docs.json

✅ includes baseUrl

```jsonc
{
// ...
"https://example.com/path/to/site/page": { /*...*/ }
//...
}
```