### PR TITLE
refactor(adapters): rename createCloudflareHandler to createWebRequestHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,15 @@ Add to `netlify.toml`:
 <details>
 <summary><strong>Cloudflare Workers</strong></summary>
 
-Cloudflare Workers can't access the filesystem, so you need to import the data directly:
+Cloudflare Workers can't access the filesystem, so you need to import the data directly. `createWebRequestHandler` returns a standard `(request: Request) => Promise<Response>` handler, so the same code works on any web-standard runtime (Cloudflare Workers, modern Netlify functions, Deno, Bun):
 
 ```javascript snippet=readme/snippet-06.js
-import { createCloudflareHandler } from 'docusaurus-plugin-mcp-server/adapters';
+import { createWebRequestHandler } from 'docusaurus-plugin-mcp-server/adapters';
 import docs from '../build/mcp/docs.json';
 import searchIndex from '../build/mcp/search-index.json';
 
 export default {
-  fetch: createCloudflareHandler({
+  fetch: createWebRequestHandler({
     docs,
     searchIndexData: searchIndex,
     name: 'my-docs',
@@ -548,7 +548,7 @@ import {
 import {
   createVercelHandler,
   createNetlifyHandler,
-  createCloudflareHandler,
+  createWebRequestHandler,
   createNodeServer,
   createNodeHandler,
   generateAdapterFiles,

--- a/snippets/readme/snippet-06.js
+++ b/snippets/readme/snippet-06.js
@@ -1,9 +1,9 @@
-import { createCloudflareHandler } from 'docusaurus-plugin-mcp-server/adapters';
+import { createWebRequestHandler } from 'docusaurus-plugin-mcp-server/adapters';
 import docs from '../build/mcp/docs.json';
 import searchIndex from '../build/mcp/search-index.json';
 
 export default {
-  fetch: createCloudflareHandler({
+  fetch: createWebRequestHandler({
     docs,
     searchIndexData: searchIndex,
     name: 'my-docs',

--- a/snippets/readme/snippet-18.js
+++ b/snippets/readme/snippet-18.js
@@ -1,7 +1,7 @@
 import {
   createVercelHandler,
   createNetlifyHandler,
-  createCloudflareHandler,
+  createWebRequestHandler,
   createNodeServer,
   createNodeHandler,
   generateAdapterFiles,

--- a/src/adapters-entry.ts
+++ b/src/adapters-entry.ts
@@ -7,7 +7,7 @@
 export {
   createVercelHandler,
   createNetlifyHandler,
-  createCloudflareHandler,
+  createWebRequestHandler,
   createNodeServer,
   createNodeHandler,
   generateAdapterFiles,
@@ -16,7 +16,10 @@ export {
   type NetlifyEvent,
   type NetlifyContext,
   type NodeServerOptions,
+  type WebRequestAdapterConfig,
+  // Deprecated aliases, kept for one release.
+  createCloudflareHandler,
+  type CloudflareAdapterConfig,
 } from './adapters/index.js';
 
 export type { Platform, GeneratorOptions, GeneratedFile } from './adapters/generator.js';
-export type { CloudflareAdapterConfig } from './adapters/cloudflare.js';

--- a/src/adapters/generator.ts
+++ b/src/adapters/generator.ts
@@ -149,12 +149,12 @@ function generateCloudflareFiles(name: string, baseUrl: string): GeneratedFile[]
  * are imported as JSON modules and passed as pre-loaded data.
  */
 
-import { createCloudflareHandler } from 'docusaurus-plugin-mcp-server/adapters';
+import { createWebRequestHandler } from 'docusaurus-plugin-mcp-server/adapters';
 import docs from '../build/mcp/docs.json';
 import searchIndex from '../build/mcp/search-index.json';
 
 export default {
-  fetch: createCloudflareHandler({
+  fetch: createWebRequestHandler({
     docs,
     searchIndexData: searchIndex,
     name: '${name}',

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -8,7 +8,13 @@
 
 export { createVercelHandler, type VercelRequest, type VercelResponse } from './vercel.js';
 export { createNetlifyHandler, type NetlifyEvent, type NetlifyContext } from './netlify.js';
-export { createCloudflareHandler, type CloudflareAdapterConfig } from './cloudflare.js';
+export {
+  createWebRequestHandler,
+  type WebRequestAdapterConfig,
+  // Deprecated aliases, kept for one release.
+  createCloudflareHandler,
+  type CloudflareAdapterConfig,
+} from './web-request.js';
 export { generateAdapterFiles } from './generator.js';
 export { createNodeServer, createNodeHandler } from './node.js';
 export type { NodeServerOptions } from './node.js';

--- a/src/adapters/web-request.ts
+++ b/src/adapters/web-request.ts
@@ -1,21 +1,23 @@
 /**
- * Cloudflare Workers adapter for MCP server
+ * Web-standard fetch handler for the MCP server
  *
- * Creates a Cloudflare Workers fetch handler for the MCP server.
- * Since Workers can't access the filesystem, this adapter requires
- * pre-loaded docs and search index data.
+ * Creates a handler with the standard `(request: Request) => Promise<Response>`
+ * signature, so it runs on any web-standard runtime — Cloudflare Workers,
+ * Netlify (modern web-standard functions), Deno, Bun, and others. Because these
+ * runtimes can't access the filesystem, this adapter requires pre-loaded docs
+ * and search index data.
  *
  * Uses the MCP SDK's WebStandardStreamableHTTPServerTransport for proper
  * protocol handling with Web Standard Request/Response.
  *
  * @example
- * // src/worker.js
- * import { createCloudflareHandler } from 'docusaurus-plugin-mcp-server/adapters';
+ * // Cloudflare Workers — src/worker.js
+ * import { createWebRequestHandler } from 'docusaurus-plugin-mcp-server/adapters';
  * import docs from '../build/mcp/docs.json';
  * import searchIndex from '../build/mcp/search-index.json';
  *
  * export default {
- *   fetch: createCloudflareHandler({
+ *   fetch: createWebRequestHandler({
  *     docs,
  *     searchIndexData: searchIndex,
  *     name: 'my-docs',
@@ -29,9 +31,9 @@ import type { ProcessedDoc, McpServerBaseConfig, McpServerDataConfig } from '../
 import { getCorsHeaders } from './cors.js';
 
 /**
- * Config for Cloudflare Workers adapter
+ * Config for the web-standard request handler
  */
-export interface CloudflareAdapterConfig extends McpServerBaseConfig {
+export interface WebRequestAdapterConfig extends McpServerBaseConfig {
   /** Pre-loaded docs data (imported from docs.json) */
   docs: Record<string, ProcessedDoc>;
   /** Pre-loaded search index data (imported from search-index.json) */
@@ -41,12 +43,14 @@ export interface CloudflareAdapterConfig extends McpServerBaseConfig {
 }
 
 /**
- * Create a Cloudflare Workers fetch handler for the MCP server
+ * Create a web-standard `(request: Request) => Promise<Response>` handler for
+ * the MCP server, suitable for any web-standard runtime (Cloudflare Workers,
+ * modern Netlify functions, Deno, Bun, etc).
  *
  * Uses the MCP SDK's WebStandardStreamableHTTPServerTransport for
  * proper protocol handling.
  */
-export function createCloudflareHandler(config: CloudflareAdapterConfig) {
+export function createWebRequestHandler(config: WebRequestAdapterConfig) {
   let server: McpDocsServer | null = null;
   const { corsOrigin, ...serverConfig } = config;
 
@@ -128,3 +132,16 @@ export function createCloudflareHandler(config: CloudflareAdapterConfig) {
     }
   };
 }
+
+/**
+ * @deprecated Renamed to `createWebRequestHandler`. The handler is not
+ * Cloudflare-specific — it works on any web-standard runtime. This alias will
+ * be removed in a future release.
+ */
+export const createCloudflareHandler = createWebRequestHandler;
+
+/**
+ * @deprecated Renamed to `WebRequestAdapterConfig`. This alias will be removed
+ * in a future release.
+ */
+export type CloudflareAdapterConfig = WebRequestAdapterConfig;

--- a/tests/adapters-test.ts
+++ b/tests/adapters-test.ts
@@ -59,7 +59,7 @@ describe('generateAdapterFiles', () => {
 
       const workerFile = files.find((f) => f.path === 'workers/mcp.js');
       expect(workerFile).toBeDefined();
-      expect(workerFile?.content).toContain('createCloudflareHandler');
+      expect(workerFile?.content).toContain('createWebRequestHandler');
       expect(workerFile?.content).toContain("name: 'my-docs'");
 
       const configFile = files.find((f) => f.path === 'wrangler.toml');


### PR DESCRIPTION
Closes #70.

## What

Renames `createCloudflareHandler` → `createWebRequestHandler` (and `CloudflareAdapterConfig` → `WebRequestAdapterConfig`), and renames the file `src/adapters/cloudflare.ts` → `src/adapters/web-request.ts`.

## Why

As @GeorgeTaveras1231 noted in #70, the handler isn't Cloudflare-specific — it returns a standard `(request: Request) => Promise<Response>` and works on any web-standard runtime. He actually had to use `createCloudflareHandler` for a **Netlify** deploy because the modern Netlify functions API is web-standard too. The new name reflects what it actually is.

## Backward compatibility

`createCloudflareHandler` and `CloudflareAdapterConfig` are kept as `@deprecated` aliases for one release, so existing imports keep working. They'll be removed in a later release.

## Scope

- Function/type rename + file rename
- Deprecated aliases (function + type)
- Generator scaffold, README, and README snippets updated to the new name
- The `'cloudflare'` generator platform target is unchanged — it just emits the renamed handler

Not in scope: George's deeper point that this same handler could back a first-class modern-Netlify adapter. Worth a follow-up.

## Verification

`build`, `typecheck`, `lint`, `test` (69/69), and `snippets:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)