### PR TITLE
fix(route-collector): discover sibling .html files (trailingSlash: false)

### DIFF
--- a/src/plugin/route-collector.ts
+++ b/src/plugin/route-collector.ts
@@ -76,9 +76,17 @@ export function filterRoutes(
   });
 }
 
+// Sibling HTMLs like `foo.html` are how Docusaurus emits pages when
+// `trailingSlash` is `false`. We skip the generated `404.html`.
+const NON_ROUTE_HTML = new Set(['404.html']);
+
 /**
  * Discover all HTML files in the build directory and create routes for them.
  * This is more reliable than using Docusaurus routes as it captures all built pages.
+ *
+ * Picks up both `path/index.html` (trailingSlash: true/undefined) and sibling
+ * `path.html` files (trailingSlash: false). When both exist for the same
+ * route, the `index.html` form wins via the dedup pass in `collectRoutes`.
  */
 export async function discoverHtmlFiles(outDir: string): Promise<FlattenedRoute[]> {
   const routes: FlattenedRoute[] = [];
@@ -95,21 +103,25 @@ export async function discoverHtmlFiles(outDir: string): Promise<FlattenedRoute[
           continue;
         }
         await scanDirectory(fullPath);
-      } else if (entry.name === 'index.html') {
-        // Convert file path back to route
-        const relativePath = path.relative(outDir, fullPath);
-        let routePath = '/' + path.dirname(relativePath).replace(/\\/g, '/');
-
-        // Handle root index.html
-        if (routePath === '/.') {
-          routePath = '/';
-        }
-
-        routes.push({
-          path: routePath,
-          htmlPath: fullPath,
-        });
+        continue;
       }
+
+      if (!entry.isFile() || !entry.name.endsWith('.html') || NON_ROUTE_HTML.has(entry.name)) {
+        continue;
+      }
+
+      const relativePath = path.relative(outDir, fullPath);
+
+      let routePath: string;
+      if (entry.name === 'index.html') {
+        const dirName = path.dirname(relativePath).replace(/\\/g, '/');
+        routePath = dirName === '.' ? '/' : '/' + dirName;
+      } else {
+        const withoutExt = relativePath.slice(0, -'.html'.length).replace(/\\/g, '/');
+        routePath = '/' + withoutExt;
+      }
+
+      routes.push({ path: routePath, htmlPath: fullPath });
     }
   }
 
@@ -153,10 +165,13 @@ export async function collectRoutes(
   // Filter out excluded routes
   const filteredRoutes = filterRoutes(allRoutes, excludePatterns);
 
-  // Deduplicate routes by path
+  // Deduplicate routes by path. When the same route is emitted as both
+  // `foo/index.html` and `foo.html`, prefer the `index.html` form so that
+  // sites which output both for redirect compatibility get a stable choice.
   const uniqueRoutes = new Map<string, FlattenedRoute>();
   for (const route of filteredRoutes) {
-    if (!uniqueRoutes.has(route.path)) {
+    const existing = uniqueRoutes.get(route.path);
+    if (!existing || path.basename(route.htmlPath) === 'index.html') {
       uniqueRoutes.set(route.path, route);
     }
   }

--- a/tests/route-collector-test.ts
+++ b/tests/route-collector-test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs-extra';
+import { collectRoutes, discoverHtmlFiles } from '../src/plugin/route-collector.js';
+
+let tmpDir: string;
+
+async function write(rel: string, contents = '<html></html>') {
+  const full = path.join(tmpDir, rel);
+  await fs.ensureDir(path.dirname(full));
+  await fs.writeFile(full, contents);
+  return full;
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'route-collector-'));
+});
+
+afterEach(async () => {
+  await fs.remove(tmpDir);
+});
+
+describe('discoverHtmlFiles', () => {
+  it('discovers index.html-style routes (trailingSlash: true)', async () => {
+    await write('index.html');
+    await write('guides/getting-started/index.html');
+    await write('api/index.html');
+
+    const routes = await discoverHtmlFiles(tmpDir);
+    const paths = routes.map((r) => r.path).sort();
+
+    expect(paths).toEqual(['/', '/api', '/guides/getting-started']);
+  });
+
+  it('discovers sibling-html routes (trailingSlash: false)', async () => {
+    await write('index.html');
+    await write('guides/getting-started.html');
+    await write('api.html');
+
+    const routes = await discoverHtmlFiles(tmpDir);
+    const paths = routes.map((r) => r.path).sort();
+
+    expect(paths).toEqual(['/', '/api', '/guides/getting-started']);
+  });
+
+  it('discovers mixed output (both forms in the same build)', async () => {
+    await write('docs/intro.html');
+    await write('docs/intro/index.html');
+    await write('blog.html');
+    await write('index.html');
+
+    const routes = await discoverHtmlFiles(tmpDir);
+    const paths = routes.map((r) => r.path).sort();
+
+    expect(paths).toEqual(['/', '/blog', '/docs/intro', '/docs/intro']);
+  });
+
+  it('skips 404.html and asset directories', async () => {
+    await write('404.html');
+    await write('assets/foo.html');
+    await write('img/bar.html');
+    await write('static/baz.html');
+    await write('real-page.html');
+
+    const routes = await discoverHtmlFiles(tmpDir);
+    const paths = routes.map((r) => r.path);
+
+    expect(paths).toEqual(['/real-page']);
+  });
+});
+
+describe('collectRoutes', () => {
+  it('prefers index.html over sibling .html on collision', async () => {
+    const sibling = await write('docs/intro.html', '<html><body>sibling</body></html>');
+    const indexed = await write('docs/intro/index.html', '<html><body>indexed</body></html>');
+
+    const routes = await collectRoutes(tmpDir, []);
+    const intro = routes.find((r) => r.path === '/docs/intro');
+
+    expect(intro?.htmlPath).toBe(indexed);
+    expect(intro?.htmlPath).not.toBe(sibling);
+  });
+
+  it('applies excludePatterns', async () => {
+    await write('public.html');
+    await write('search.html');
+    await write('search/results.html');
+
+    const routes = await collectRoutes(tmpDir, ['/search*']);
+    const paths = routes.map((r) => r.path).sort();
+
+    expect(paths).toEqual(['/public']);
+  });
+});


### PR DESCRIPTION
`discoverHtmlFiles` only picked up `index.html`, so sites built with `trailingSlash: false` (where pages are emitted as `foo.html` instead of `foo/index.html`) ended up with just the root route indexed.

Now also pick up sibling `.html` files. When the same route exists in both forms, `index.html` wins in `collectRoutes` dedup to preserve current behavior for sites that emit both for redirect compatibility.

Added `tests/route-collector-test.ts` covering both layouts, the mixed case, and excludes.