### PR TITLE
feat: configurable FlexSearch and SearchProvider instances

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -199,9 +199,11 @@ export class McpDocsServer {
   }
 
   private async _doInitialize(): Promise<void> {
-    // Load the search provider
+    // Load the search provider (specifier string or pre-instantiated provider)
     const searchSpecifier = this.config.search ?? 'flexsearch';
-    this.searchProvider = await loadSearchProvider(searchSpecifier);
+    this.searchProvider = await loadSearchProvider(searchSpecifier, {
+      flexsearch: this.config.flexsearch,
+    });
 
     // Build provider context
     const providerContext: ProviderContext = {

--- a/src/plugin/docusaurus-plugin.ts
+++ b/src/plugin/docusaurus-plugin.ts
@@ -175,7 +175,9 @@ export default function mcpServerPlugin(
 
       for (const indexerSpec of indexerSpecs) {
         try {
-          const indexer = await loadIndexer(indexerSpec);
+          const indexer = await loadIndexer(indexerSpec, {
+            flexsearch: resolvedOptions.flexsearch,
+          });
 
           // Check if indexer wants to run (env var gating)
           if (indexer.shouldRun && !indexer.shouldRun()) {

--- a/src/providers/indexers/flexsearch-indexer.ts
+++ b/src/providers/indexers/flexsearch-indexer.ts
@@ -1,4 +1,4 @@
-import type { ProcessedDoc } from '../../types/index.js';
+import type { FlexSearchConfig, ProcessedDoc } from '../../types/index.js';
 import type { ContentIndexer, ProviderContext } from '../types.js';
 import { buildSearchIndex, exportSearchIndex } from '../../search/flexsearch-core.js';
 
@@ -16,6 +16,11 @@ export class FlexSearchIndexer implements ContentIndexer {
   private docsIndex: Record<string, ProcessedDoc> = {};
   private exportedIndex: unknown = null;
   private docCount = 0;
+  private readonly config?: FlexSearchConfig;
+
+  constructor(config?: FlexSearchConfig) {
+    this.config = config;
+  }
 
   /**
    * FlexSearch indexer always runs by default.
@@ -44,7 +49,7 @@ export class FlexSearchIndexer implements ContentIndexer {
 
     // Build and export FlexSearch index (use full URLs as document IDs)
     console.log('[FlexSearch] Building search index...');
-    const searchIndex = buildSearchIndex(docs, this.baseUrl);
+    const searchIndex = buildSearchIndex(docs, this.baseUrl, this.config);
     this.exportedIndex = await exportSearchIndex(searchIndex);
     console.log(`[FlexSearch] Indexed ${this.docCount} documents`);
   }

--- a/src/providers/loader.ts
+++ b/src/providers/loader.ts
@@ -1,28 +1,38 @@
+import type { FlexSearchConfig } from '../types/index.js';
 import type { ContentIndexer, SearchProvider } from './types.js';
+
+/**
+ * Options forwarded to the built-in 'flexsearch' indexer/provider.
+ * Ignored for custom specifiers.
+ */
+export interface BuiltinIndexerOptions {
+  flexsearch?: FlexSearchConfig;
+}
 
 /**
  * Load an indexer by name or module path.
  *
  * @param specifier - Either 'flexsearch' for the built-in indexer, or a module path
  *                    (relative path like './my-indexer.js' or npm package like '@myorg/indexer')
+ * @param builtinOptions - Options passed to the built-in indexer constructor (ignored for custom specifiers)
  * @returns Instantiated ContentIndexer
  *
  * @example
  * ```typescript
- * // Built-in
- * const indexer = await loadIndexer('flexsearch');
+ * // Built-in with overrides
+ * const indexer = await loadIndexer('flexsearch', { flexsearch: { tokenize: 'strict' } });
  *
  * // Custom relative path
  * const indexer = await loadIndexer('./src/providers/algolia-indexer.js');
- *
- * // Custom npm package
- * const indexer = await loadIndexer('@myorg/custom-indexer');
  * ```
  */
-export async function loadIndexer(specifier: string): Promise<ContentIndexer> {
+export async function loadIndexer(
+  specifier: string,
+  builtinOptions?: BuiltinIndexerOptions
+): Promise<ContentIndexer> {
   if (specifier === 'flexsearch') {
     const { FlexSearchIndexer } = await import('./indexers/flexsearch-indexer.js');
-    return new FlexSearchIndexer();
+    return new FlexSearchIndexer(builtinOptions?.flexsearch);
   }
 
   try {
@@ -60,28 +70,41 @@ export async function loadIndexer(specifier: string): Promise<ContentIndexer> {
 }
 
 /**
- * Load a search provider by name or module path.
+ * Load a search provider by name, module path, or instance.
  *
- * @param specifier - Either 'flexsearch' for the built-in provider, or a module path
- *                    (relative path like './my-search.js' or npm package like '@myorg/search')
+ * @param specifier - 'flexsearch' for the built-in provider, a module path to
+ *                    dynamically import, or a {@link SearchProvider} instance.
+ *                    Pass an instance when running in a bundled environment
+ *                    where dynamic `import()` of arbitrary specifiers is not
+ *                    available (e.g. Cloudflare Workers).
+ * @param builtinOptions - Options passed to the built-in provider constructor (ignored otherwise)
  * @returns Instantiated SearchProvider
  *
  * @example
  * ```typescript
- * // Built-in
- * const provider = await loadSearchProvider('flexsearch');
+ * // Built-in with overrides
+ * const provider = await loadSearchProvider('flexsearch', { flexsearch: { tokenize: 'strict' } });
  *
- * // Custom relative path
- * const provider = await loadSearchProvider('./src/providers/glean-search.js');
- *
- * // Custom npm package
- * const provider = await loadSearchProvider('@myorg/glean-search');
+ * // Pre-instantiated (Workers / bundled environments)
+ * const provider = await loadSearchProvider(new MyProvider());
  * ```
  */
-export async function loadSearchProvider(specifier: string): Promise<SearchProvider> {
+export async function loadSearchProvider(
+  specifier: string | SearchProvider,
+  builtinOptions?: BuiltinIndexerOptions
+): Promise<SearchProvider> {
+  if (typeof specifier !== 'string') {
+    if (!isSearchProvider(specifier)) {
+      throw new Error(
+        'Invalid search provider instance: does not implement SearchProvider interface'
+      );
+    }
+    return specifier;
+  }
+
   if (specifier === 'flexsearch') {
     const { FlexSearchProvider } = await import('./search/flexsearch-provider.js');
-    return new FlexSearchProvider();
+    return new FlexSearchProvider(builtinOptions?.flexsearch);
   }
 
   try {

--- a/src/providers/search/flexsearch-provider.ts
+++ b/src/providers/search/flexsearch-provider.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import type { ProcessedDoc, SearchResult } from '../../types/index.js';
+import type { FlexSearchConfig, ProcessedDoc, SearchResult } from '../../types/index.js';
 import type {
   SearchProvider,
   ProviderContext,
@@ -24,6 +24,11 @@ export class FlexSearchProvider implements SearchProvider {
   private docs: Record<string, ProcessedDoc> | null = null;
   private searchIndex: FlexSearchDocument | null = null;
   private ready = false;
+  private readonly config?: FlexSearchConfig;
+
+  constructor(config?: FlexSearchConfig) {
+    this.config = config;
+  }
 
   async initialize(_context: ProviderContext, initData?: SearchProviderInitData): Promise<void> {
     if (!initData) {
@@ -33,7 +38,10 @@ export class FlexSearchProvider implements SearchProvider {
     // Pre-loaded data mode (Cloudflare Workers, etc.)
     if (initData.docs && initData.indexData) {
       this.docs = initData.docs;
-      this.searchIndex = await importSearchIndex(initData.indexData as Record<string, unknown>);
+      this.searchIndex = await importSearchIndex(
+        initData.indexData as Record<string, unknown>,
+        this.config
+      );
       this.ready = true;
       return;
     }
@@ -48,7 +56,7 @@ export class FlexSearchProvider implements SearchProvider {
 
       if (await fs.pathExists(initData.indexPath)) {
         const indexData = await fs.readJson(initData.indexPath);
-        this.searchIndex = await importSearchIndex(indexData);
+        this.searchIndex = await importSearchIndex(indexData, this.config);
       } else {
         throw new Error(`[FlexSearch] Search index not found: ${initData.indexPath}`);
       }
@@ -72,7 +80,10 @@ export class FlexSearchProvider implements SearchProvider {
     }
 
     const limit = options?.limit ?? 16;
-    return querySearchIndex(this.searchIndex, this.docs, query, { limit });
+    return querySearchIndex(this.searchIndex, this.docs, query, {
+      limit,
+      fieldWeights: this.config?.fieldWeights,
+    });
   }
 
   async getDocument(url: string): Promise<ProcessedDoc | null> {

--- a/src/search/flexsearch-core.ts
+++ b/src/search/flexsearch-core.ts
@@ -1,19 +1,30 @@
 import FlexSearch from 'flexsearch';
-import type { ProcessedDoc, SearchResult } from '../types/index.js';
+import type {
+  FlexSearchConfig,
+  FlexSearchField,
+  ProcessedDoc,
+  SearchResult,
+} from '../types/index.js';
 import type { IndexableDocument } from './types.js';
 
 export type FlexSearchDocument = FlexSearch.Document<IndexableDocument, string[]>;
 
 /**
- * Field weights for search ranking
+ * Default field weights for search ranking
  * Higher values = more importance
  */
-const FIELD_WEIGHTS = {
+export const DEFAULT_FIELD_WEIGHTS: Record<FlexSearchField, number> = {
   title: 3.0,
   headings: 2.0,
   description: 1.5,
   content: 1.0,
-} as const;
+};
+
+function resolveFieldWeights(
+  overrides?: FlexSearchConfig['fieldWeights']
+): Record<FlexSearchField, number> {
+  return { ...DEFAULT_FIELD_WEIGHTS, ...overrides };
+}
 
 /**
  * Simple English stemmer
@@ -47,48 +58,48 @@ function englishStemmer(word: string): string {
   );
 }
 
+const DEFAULT_FLEXSEARCH_CONFIG = {
+  tokenize: 'forward' as const,
+  cache: 100,
+  resolution: 9,
+  context: { resolution: 2, depth: 2, bidirectional: true },
+  encode: (str: string) =>
+    str
+      .toLowerCase()
+      .split(/[\s\-_.,;:!?'"()[\]{}]+/)
+      .filter(Boolean)
+      .map(englishStemmer),
+};
+
 /**
- * Create a FlexSearch document index with enhanced configuration
+ * Create a FlexSearch document index.
  *
- * Features:
- * - Forward-prefix tokenization (finds "auth" in "authentication", avoids OOM on large doc sets)
- * - English stemming (finds "authenticate" when searching "authentication")
- * - Context-aware scoring for phrase matching
- * - Optimized resolution for relevance ranking
+ * Defaults are tuned for English: forward-prefix tokenization, English
+ * stemming, bidirectional context for phrase matching, max resolution.
+ * Pass `config` to override any of these — useful for non-English content
+ * or large doc sets where the defaults produce an oversized index.
+ *
+ * If a custom config is passed at build time, the same config must be
+ * passed at runtime to {@link importSearchIndex} (and to the search
+ * provider), otherwise the deserialized index returns no results.
  */
-export function createSearchIndex(): FlexSearchDocument {
+export function createSearchIndex(config?: FlexSearchConfig): FlexSearchDocument {
+  // `false` means caller explicitly disabled context; pass it through.
+  // Otherwise fall back to the bundled default.
+  const context =
+    config?.context === false
+      ? (false as unknown as { resolution?: number; depth?: number; bidirectional?: boolean })
+      : (config?.context ?? DEFAULT_FLEXSEARCH_CONFIG.context);
+
   return new FlexSearch.Document<IndexableDocument, string[]>({
-    // Use 'forward' tokenization to avoid OOM with large doc sets
-    // See: https://github.com/scalvert/docusaurus-plugin-mcp-server/issues/11
-    tokenize: 'forward',
-
-    // Enable caching for faster repeated queries
-    cache: 100,
-
-    // Higher resolution = more granular ranking (1-9)
-    resolution: 9,
-
-    // Enable context for phrase/proximity matching
-    context: {
-      resolution: 2,
-      depth: 2,
-      bidirectional: true,
-    },
-
-    // Apply stemming to normalize word forms
-    encode: (str: string) => {
-      // Normalize to lowercase and split into words
-      const words = str.toLowerCase().split(/[\s\-_.,;:!?'"()[\]{}]+/);
-      // Apply stemmer to each word
-      return words.filter(Boolean).map(englishStemmer);
-    },
-
-    // Document schema
+    tokenize: config?.tokenize ?? DEFAULT_FLEXSEARCH_CONFIG.tokenize,
+    cache: config?.cache ?? DEFAULT_FLEXSEARCH_CONFIG.cache,
+    resolution: config?.resolution ?? DEFAULT_FLEXSEARCH_CONFIG.resolution,
+    context,
+    encode: config?.encode ?? DEFAULT_FLEXSEARCH_CONFIG.encode,
     document: {
       id: 'id',
-      // Index these fields for searching
       index: ['title', 'content', 'headings', 'description'],
-      // Store these fields in results (for enriched queries)
       store: ['title', 'description'],
     },
   });
@@ -126,8 +137,12 @@ export function addDocumentToIndex(
  * @param docs - Documents to index
  * @param baseUrl - Optional base URL to construct full URLs as document IDs
  */
-export function buildSearchIndex(docs: ProcessedDoc[], baseUrl?: string): FlexSearchDocument {
-  const index = createSearchIndex();
+export function buildSearchIndex(
+  docs: ProcessedDoc[],
+  baseUrl?: string,
+  config?: FlexSearchConfig
+): FlexSearchDocument {
+  const index = createSearchIndex(config);
 
   for (const doc of docs) {
     addDocumentToIndex(index, doc, baseUrl);
@@ -147,9 +162,10 @@ export function querySearchIndex(
   index: FlexSearchDocument,
   docs: Record<string, ProcessedDoc>,
   query: string,
-  options: { limit?: number } = {}
+  options: { limit?: number; fieldWeights?: FlexSearchConfig['fieldWeights'] } = {}
 ): SearchResult[] {
-  const { limit = 16 } = options;
+  const { limit = 16, fieldWeights } = options;
+  const weights = resolveFieldWeights(fieldWeights);
 
   // Search across all fields
   const rawResults = index.search(query, {
@@ -162,8 +178,8 @@ export function querySearchIndex(
 
   for (const fieldResult of rawResults) {
     // Determine which field this result is from
-    const field = fieldResult.field as keyof typeof FIELD_WEIGHTS;
-    const fieldWeight = FIELD_WEIGHTS[field] ?? 1.0;
+    const field = fieldResult.field as FlexSearchField;
+    const fieldWeight = weights[field] ?? 1.0;
 
     // With enrich: true, results are objects with id property
     const results = fieldResult.result as unknown as Array<{ id: string } | string>;
@@ -308,9 +324,10 @@ export async function exportSearchIndex(index: FlexSearchDocument): Promise<unkn
  * Import a search index from serialized data
  */
 export async function importSearchIndex(
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
+  config?: FlexSearchConfig
 ): Promise<FlexSearchDocument> {
-  const index = createSearchIndex();
+  const index = createSearchIndex(config);
 
   for (const [key, value] of Object.entries(data)) {
     // FlexSearch's import expects the data in a specific format

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,38 @@
+import type { SearchProvider } from '../providers/types.js';
+
+/**
+ * Field name in the search index. Higher weight = ranked higher when matched.
+ */
+export type FlexSearchField = 'title' | 'headings' | 'description' | 'content';
+
+/**
+ * Overrides for the built-in FlexSearch index configuration.
+ *
+ * The defaults are tuned for English content. Sites with long compound
+ * words (e.g. German, Finnish) or large doc sets may want to relax
+ * `tokenize`, drop `context`, or lower `resolution` to reduce
+ * index size.
+ *
+ * The same config must be supplied at build time (via plugin options)
+ * AND at runtime (via `McpServerBaseConfig.flexsearch`). Otherwise the
+ * runtime provider deserializes the index with the wrong shape and
+ * returns no results.
+ */
+export interface FlexSearchConfig {
+  /** Tokenization mode. Default: 'forward'. Use 'strict' for whole-word-only. */
+  tokenize?: 'strict' | 'forward' | 'reverse' | 'full';
+  /** Ranking resolution 1-9. Default: 9. Lower = smaller index. */
+  resolution?: number;
+  /** Phrase/proximity context. Default: { resolution: 2, depth: 2, bidirectional: true }. Set to false to disable (much smaller index). */
+  context?: false | { resolution?: number; depth?: number; bidirectional?: boolean };
+  /** Query result cache. Default: 100. */
+  cache?: number | boolean;
+  /** Custom tokenizer. Default: lowercase split + English stemmer. */
+  encode?: (str: string) => string[];
+  /** Weights applied per field during ranking. Defaults: title 3, headings 2, description 1.5, content 1. */
+  fieldWeights?: Partial<Record<FlexSearchField, number>>;
+}
+
 /**
  * Configuration options for the MCP server plugin
  */
@@ -44,6 +79,12 @@ export interface McpServerPluginOptions {
    * - '@myorg/glean-search' (npm package)
    */
   search?: string;
+
+  /**
+   * Overrides for the built-in FlexSearch indexer/provider. See {@link FlexSearchConfig}.
+   * Ignored when a custom indexer/provider is used.
+   */
+  flexsearch?: FlexSearchConfig;
 }
 
 /**
@@ -63,6 +104,8 @@ export interface ResolvedPluginOptions {
   indexers: string[] | false | undefined;
   /** Search provider module */
   search: string;
+  /** FlexSearch overrides for the built-in indexer/provider. */
+  flexsearch?: FlexSearchConfig;
 }
 
 /**
@@ -171,8 +214,21 @@ export interface McpServerBaseConfig {
   version?: string;
   /** Base URL for constructing full page URLs (e.g., https://docs.example.com) */
   baseUrl?: string;
-  /** Search provider module. Default: 'flexsearch' */
-  search?: string;
+  /**
+   * Search provider. Default: 'flexsearch'.
+   *
+   * Accepts either a module specifier (string) loaded via dynamic `import()`,
+   * or a {@link SearchProvider} instance. Pass an instance when running in a
+   * bundled environment (Cloudflare Workers, etc.) where dynamic import of
+   * arbitrary specifiers is not available.
+   */
+  search?: string | SearchProvider;
+  /**
+   * Overrides for the built-in FlexSearch provider. See {@link FlexSearchConfig}.
+   * Must match the config used at index build time. Ignored when `search` is
+   * a custom provider.
+   */
+  flexsearch?: FlexSearchConfig;
   /**
    * Instructions describing how to use the server and its tools.
    * Surfaced to MCP clients in the initialize response.

--- a/tests/providers-test.ts
+++ b/tests/providers-test.ts
@@ -188,6 +188,21 @@ describe('Provider Loader', () => {
     it('should throw error for non-existent module', async () => {
       await expect(loadIndexer('./non-existent-module.js')).rejects.toThrow();
     });
+
+    it('forwards flexsearch overrides to the built-in indexer', async () => {
+      const indexer = (await loadIndexer('flexsearch', {
+        flexsearch: { tokenize: 'strict', context: false },
+      })) as FlexSearchIndexer;
+      await indexer.initialize(mockProviderContext);
+      await indexer.indexDocuments(mockDocs);
+      const indexed = (await indexer.finalize()).get('search-index.json') as Record<
+        string,
+        unknown
+      >;
+      // Smoke-check: the indexer ran and produced FlexSearch's expected layout.
+      expect(indexed).toHaveProperty('reg');
+      expect(indexed).toHaveProperty('content.map');
+    });
   });
 
   describe('loadSearchProvider', () => {
@@ -200,5 +215,36 @@ describe('Provider Loader', () => {
     it('should throw error for non-existent module', async () => {
       await expect(loadSearchProvider('./non-existent-module.js')).rejects.toThrow();
     });
+
+    it('returns a SearchProvider instance passed directly', async () => {
+      const instance = new FlexSearchProvider();
+      const loaded = await loadSearchProvider(instance);
+      expect(loaded).toBe(instance);
+    });
+
+    it('rejects an object that does not implement SearchProvider', async () => {
+      await expect(
+        loadSearchProvider({ name: 'broken' } as unknown as FlexSearchProvider)
+      ).rejects.toThrow(/does not implement SearchProvider/);
+    });
+  });
+});
+
+describe('FlexSearchIndexer with custom config', () => {
+  it('produces a smaller index when context is disabled', async () => {
+    const defaultIndexer = new FlexSearchIndexer();
+    const leanIndexer = new FlexSearchIndexer({ tokenize: 'strict', context: false });
+
+    for (const indexer of [defaultIndexer, leanIndexer]) {
+      await indexer.initialize(mockProviderContext);
+      await indexer.indexDocuments(mockDocs);
+    }
+
+    const defaultSize = JSON.stringify(
+      (await defaultIndexer.finalize()).get('search-index.json')
+    ).length;
+    const leanSize = JSON.stringify((await leanIndexer.finalize()).get('search-index.json')).length;
+
+    expect(leanSize).toBeLessThan(defaultSize);
   });
 });


### PR DESCRIPTION
Two related changes that come up when running the plugin against non-English content from a bundled environment.

### `flexsearch` option

The bundled FlexSearch config (`tokenize: 'forward'`, `context: { resolution: 2, depth: 2, bidirectional: true }`, `resolution: 9`) is tuned for English. For sites with long compound words or large doc sets it produces a multi-megabyte `search-index.json`. There's no way to dial it back without forking the indexer.

Adds `flexsearch?: FlexSearchConfig` to `McpServerPluginOptions` and `McpServerBaseConfig`:

```ts
{
  flexsearch: {
    tokenize: 'strict',
    context: false,
    resolution: 3,
    fieldWeights: { title: 4 },
  },
}
```

Defaults are unchanged. Threaded through `loadIndexer`/`loadSearchProvider` via a new `builtinOptions` arg (forwarded only to the built-in, ignored for custom specifiers). Documented that build-time and runtime configs must match.

### `search` accepts a SearchProvider instance

`loadSearchProvider` only takes a module specifier and uses dynamic `import()` to resolve it. That doesn't work in bundled environments (Cloudflare Workers, Vercel Edge with esbuild) where arbitrary specifiers can't be resolved at runtime. Currently the only workaround is monkey-patching `McpDocsServer.prototype._doInitialize`.

`search` now accepts either a string or a pre-instantiated `SearchProvider`:

```ts
new McpDocsServer({
  docs, searchIndexData,
  name: 'docs',
  search: new MyProvider(),
})
```

The string path is unchanged.

### Tests

4 new tests in `tests/providers-test.ts`: forwarding flexsearch options, accepting a provider instance, rejecting a non-provider object, and a smoke check on a custom-config indexer. 69 total, all green. Lint clean.