### PR TITLE
refactor(adapters)!: remove deprecated createCloudflareHandler alias

### DIFF
--- a/src/adapters-entry.ts
+++ b/src/adapters-entry.ts
@@ -11,7 +11,4 @@ export {
   createNodeHandler,
   type NodeServerOptions,
   type WebRequestAdapterConfig,
-  // Deprecated aliases, kept for one release.
-  createCloudflareHandler,
-  type CloudflareAdapterConfig,
 } from './adapters/index.js';

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -7,12 +7,6 @@
  * server over Node's `http` module.
  */
 
-export {
-  createWebRequestHandler,
-  type WebRequestAdapterConfig,
-  // Deprecated aliases, kept for one release.
-  createCloudflareHandler,
-  type CloudflareAdapterConfig,
-} from './web-request.js';
+export { createWebRequestHandler, type WebRequestAdapterConfig } from './web-request.js';
 export { createNodeServer, createNodeHandler } from './node.js';
 export type { NodeServerOptions } from './node.js';

--- a/src/adapters/web-request.ts
+++ b/src/adapters/web-request.ts
@@ -132,16 +132,3 @@ export function createWebRequestHandler(config: WebRequestAdapterConfig) {
     }
   };
 }
-
-/**
- * @deprecated Renamed to `createWebRequestHandler`. The handler is not
- * Cloudflare-specific — it works on any web-standard runtime. This alias will
- * be removed in a future release.
- */
-export const createCloudflareHandler = createWebRequestHandler;
-
-/**
- * @deprecated Renamed to `WebRequestAdapterConfig`. This alias will be removed
- * in a future release.
- */
-export type CloudflareAdapterConfig = WebRequestAdapterConfig;


### PR DESCRIPTION
Completes the adapter consolidation (#74, #75). Removes the `createCloudflareHandler` / `CloudflareAdapterConfig` aliases that were kept for one release after the rename to `createWebRequestHandler`.

## Breaking change

`createCloudflareHandler` and `CloudflareAdapterConfig` are removed. Migrate:

```diff
-import { createCloudflareHandler, type CloudflareAdapterConfig } from 'docusaurus-plugin-mcp-server/adapters';
+import { createWebRequestHandler, type WebRequestAdapterConfig } from 'docusaurus-plugin-mcp-server/adapters';
```

They were exact aliases, so the swap is name-only — no behavior change.

## Why now

This is the last API-stability gate before 1.0.0: the adapter surface is now a single generic web-standard handler (`createWebRequestHandler`) plus the Node local-dev server, with no legacy names lingering.

## Verification

typecheck, eslint, build, 75/75 tests, and snippets:check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)