### PR TITLE
docs: add 0.13.0 to 1.0.0 migration guide

### DIFF
--- a/migrations/0.13.0-1.0.0.md
+++ b/migrations/0.13.0-1.0.0.md
@@ -1,0 +1,73 @@
+# Migrating from 0.13.0 to 1.0.0
+
+1.0.0 removes the deprecated `createCloudflareHandler` / `CloudflareAdapterConfig`
+aliases that 0.13.0 kept for one release. That is the **only** breaking change
+between 0.13.0 and 1.0.0.
+
+If you are upgrading from 0.12.x or earlier, also read
+[Upgrading from 0.12.x](#upgrading-from-012x-or-earlier) below.
+
+## Required change: use the web-standard handler name
+
+`createCloudflareHandler` was renamed to `createWebRequestHandler` — it was never
+Cloudflare-specific. It returns a standard `(request: Request) => Promise<Response>`
+and runs on any web-standard runtime (Cloudflare Workers, modern Netlify
+functions, Vercel Edge, Deno, Bun). The old name was a deprecated alias in 0.13.0
+and is removed in 1.0.0. The function and its config are otherwise identical —
+this is a name change only, with no runtime behavior change.
+
+Handler:
+
+```diff
+-import { createCloudflareHandler } from 'docusaurus-plugin-mcp-server/adapters';
++import { createWebRequestHandler } from 'docusaurus-plugin-mcp-server/adapters';
+
+ export default {
+-  fetch: createCloudflareHandler({
++  fetch: createWebRequestHandler({
+     docs,
+     searchIndexData: searchIndex,
+     name: 'my-docs',
+     baseUrl: 'https://docs.example.com',
+   }),
+ };
+```
+
+Type reference:
+
+```diff
+-import type { CloudflareAdapterConfig } from 'docusaurus-plugin-mcp-server/adapters';
++import type { WebRequestAdapterConfig } from 'docusaurus-plugin-mcp-server/adapters';
+```
+
+## For agents
+
+To convert a project from 0.13.0 to 1.0.0, in files that import from
+`docusaurus-plugin-mcp-server/adapters`:
+
+1. Replace every `createCloudflareHandler` identifier with `createWebRequestHandler`.
+2. Replace every `CloudflareAdapterConfig` type with `WebRequestAdapterConfig`.
+
+No other changes are required for this upgrade.
+
+## Upgrading from 0.12.x or earlier
+
+If you skipped 0.13.0, the adapter layer was consolidated to a single generic
+web-standard handler. These exports were **removed** (with no aliases):
+
+- `createVercelHandler`, `VercelRequest`, `VercelResponse`
+- `createNetlifyHandler`, `NetlifyEvent`, `NetlifyContext`
+- `generateAdapterFiles`, `Platform`, `GeneratorOptions`, `GeneratedFile`
+
+Deploy instead with `createWebRequestHandler`, passing **pre-loaded data** (import
+`build/mcp/docs.json` and `build/mcp/search-index.json` as modules) rather than
+filesystem paths, on a web-standard runtime. Each platform differs only in the
+export wrapper:
+
+- Cloudflare Workers / Deno / Bun: `export default { fetch: handler }`
+- Modern Netlify functions: `export default async (request) => handler(request)`
+- Vercel: use the Edge runtime (`export const config = { runtime: 'edge' }`)
+
+For local development, use `createNodeServer` / `createNodeHandler`
+(filesystem-based, Node `http`). The agent skill shipped under `skills/` describes
+the per-platform wrapper and config (e.g. Cloudflare `wrangler.toml`) in detail.


### PR DESCRIPTION
Adds a `migrations/` directory with a per-release, agent-pointable guide (`migrations/0.13.0-1.0.0.md`).

- The 0.13.0 to 1.0.0 delta is just the `createCloudflareHandler` -> `createWebRequestHandler` alias removal (name-only), with explicit before/after diffs and a "For agents" section giving exact find/replace instructions.
- A trailing section covers the full adapter consolidation for anyone upgrading straight from 0.12.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)