### PR TITLE
chore(deps): bump actions/checkout to v7

### DIFF
--- a/.github/workflows/agent-baseline.yml
+++ b/.github/workflows/agent-baseline.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: '20'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup mise
         uses: jdx/mise-action@v4
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup mise
         uses: jdx/mise-action@v4
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup mise
         uses: jdx/mise-action@v4


### PR DESCRIPTION
Applies Dependabot #84 directly — it conflicted with the `setup-node` bump (#83) that merged first. Bumps `actions/checkout` to v7 across `ci.yml` and `agent-baseline.yml`. Supersedes #84.