### PR TITLE
fix(1.0.0): export missing config types, correct stale docs, add API smoke tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ npx vitest run tests/html-to-markdown-test.ts
 
 - `src/plugin/` — Docusaurus plugin (build-time processing)
 - `src/mcp/` — MCP server and tool definitions
-- `src/adapters/` — Platform adapters (Vercel, Netlify, Cloudflare, Node)
+- `src/adapters/` — Runtime handlers (`web-request.ts` for serverless/edge, `node.ts` for local dev)
 - `src/processing/` — HTML parsing and markdown conversion
 - `src/search/` — FlexSearch integration
 - `src/providers/` — Pluggable indexer and search provider system

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ The button shows a dropdown with copy-to-clipboard configurations for all suppor
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `serverUrl` | `string` | required | Your MCP server endpoint URL |
-| `serverName` | `string` | required | Name for the MCP server |
+| `serverUrl` | `string` | (plugin config) | MCP server endpoint URL. Falls back to the plugin's global data when omitted |
+| `serverName` | `string` | (plugin config) | MCP server name. Falls back to the plugin's global data when omitted |
 | `label` | `string` | (none) | Button label. If omitted, shows only the MCP icon |
 | `headerText` | `string` | `"Choose your AI tool:"` | Text shown at the top of the dropdown |
 | `className` | `string` | `""` | Optional CSS class |
@@ -418,8 +418,8 @@ The plugin operates in two phases:
 
 - **Full-text Search** - FlexSearch-powered search with relevance ranking
 - **Page Retrieval** - Get complete page content as clean markdown
-- **Platform Adapters** - Pre-built adapters for Vercel, Netlify, and Cloudflare Workers
-- **CORS Support** - All adapters include CORS headers for browser-based clients
+- **Runs Anywhere** - One web-standard handler (`createWebRequestHandler`) for any serverless/edge runtime — Cloudflare Workers, modern Netlify functions, Vercel Edge, Deno, Bun — plus a Node server (`createNodeServer`) for local development
+- **CORS Support** - The web and Node handlers send CORS headers for browser-based clients; restrict with `corsOrigin`
 - **Build-time Processing** - Extracts content from rendered HTML, capturing React component output
 - **Zero Runtime Docusaurus Dependency** - The MCP server runs independently
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "format": "prettier --write .",
     "lint": "eslint src/ tests/ && prettier --check .",
     "lint:fix": "eslint src/ tests/ --fix && prettier --write .",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run lint && npm run typecheck && npm run test && npm run build",
     "snippets:check": "markdown-code check",
     "snippets:sync": "markdown-code sync",
     "test": "vitest run",

--- a/skills/docusaurus-plugin-mcp-server/SKILL.md
+++ b/skills/docusaurus-plugin-mcp-server/SKILL.md
@@ -35,7 +35,7 @@ Peers: `@docusaurus/core` (and `react`/`react-dom` for the theme button) are opt
 
 ## Authoritative API
 
-The authoritative API is the published TypeScript types. Read the `.d.ts` files referenced by `exports` in `package.json` before writing calls — do not guess signatures:
+The authoritative API is the published TypeScript types. Read the `.d.ts` files referenced by `exports` in `package.json` before writing calls — do not guess signatures. `dist/` is a build artifact (git-ignored), so in a fresh clone run `npm run build` first, or read the corresponding `src/*.ts`:
 
 - `.` → `dist/index.d.ts` (plugin options, `McpDocsServer`, provider/`ProcessedDoc` types)
 - `./adapters` → `dist/adapters-entry.d.ts` (`WebRequestAdapterConfig`, shared `McpServerBaseConfig`/`McpServerDataConfig`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
   McpServerDataConfig,
   DocsSearchParams,
   DocsFetchParams,
+  FlexSearchConfig,
 } from './types/index.js';
 
 export { DEFAULT_PLUGIN_OPTIONS } from './types/index.js';
@@ -29,6 +30,7 @@ export type {
 } from './providers/types.js';
 
 export { loadIndexer, loadSearchProvider } from './providers/loader.js';
+export type { BuiltinIndexerOptions } from './providers/loader.js';
 
 export { docsSearchTool } from './mcp/tools/docs-search.js';
 export { docsFetchTool } from './mcp/tools/docs-fetch.js';

--- a/tests/public-exports-test.ts
+++ b/tests/public-exports-test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import mcpServerPluginDefault, {
+  mcpServerPlugin,
+  DEFAULT_PLUGIN_OPTIONS,
+  docsSearchTool,
+  docsFetchTool,
+} from 'docusaurus-plugin-mcp-server';
+import { createNodeHandler } from 'docusaurus-plugin-mcp-server/adapters/node';
+import type { LoadContext } from '@docusaurus/types';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+// Locks the stable 1.0.0 public surface: these symbols are exported and
+// documented, so a regression in their shape is a breaking change.
+describe('public API surface', () => {
+  it('default export is the same plugin factory as the named mcpServerPlugin', () => {
+    expect(mcpServerPluginDefault).toBe(mcpServerPlugin);
+  });
+
+  it('mcpServerPlugin returns a Docusaurus plugin with the expected name and hooks', () => {
+    const context = {
+      siteConfig: { url: 'https://docs.example.com', baseUrl: '/' },
+    } as unknown as LoadContext;
+
+    const plugin = mcpServerPlugin(context, { server: { name: 'test-docs' } });
+
+    expect(plugin.name).toBe('docusaurus-plugin-mcp-server');
+    expect(typeof plugin.postBuild).toBe('function');
+    expect(typeof plugin.contentLoaded).toBe('function');
+  });
+
+  it('DEFAULT_PLUGIN_OPTIONS exposes the documented defaults', () => {
+    expect(DEFAULT_PLUGIN_OPTIONS.outputDir).toBe('mcp');
+    expect(DEFAULT_PLUGIN_OPTIONS.minContentLength).toBe(50);
+    expect(DEFAULT_PLUGIN_OPTIONS.search).toBe('flexsearch');
+    expect(DEFAULT_PLUGIN_OPTIONS.excludeRoutes).toEqual(['/404*', '/search*']);
+    expect(DEFAULT_PLUGIN_OPTIONS.server.name).toBe('docs-mcp-server');
+    expect(DEFAULT_PLUGIN_OPTIONS.contentSelectors[0]).toBe('article');
+  });
+
+  it('tool definitions expose stable names and input schemas', () => {
+    expect(docsSearchTool.name).toBe('docs_search');
+    expect(docsSearchTool.inputSchema).toBeDefined();
+    expect(docsFetchTool.name).toBe('docs_fetch');
+    expect(docsFetchTool.inputSchema).toBeDefined();
+  });
+
+  it('createNodeHandler returns a handler that answers CORS preflight with 204', async () => {
+    const handler = createNodeHandler({ name: 'test', docs: {}, searchIndexData: {} });
+    expect(typeof handler).toBe('function');
+
+    const headers: Record<string, string> = {};
+    const res = {
+      setHeader: (k: string, v: string) => {
+        headers[k] = v;
+      },
+      writeHead: vi.fn(),
+      end: vi.fn(),
+    } as unknown as ServerResponse;
+    const req = { method: 'OPTIONS' } as IncomingMessage;
+
+    await handler(req, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(204);
+    expect(headers['Access-Control-Allow-Origin']).toBe('*');
+  });
+});


### PR DESCRIPTION
## What

Release-readiness polish surfaced by a full audit of the 1.0.0 public surface.

### API completeness
- Export `FlexSearchConfig` and `BuiltinIndexerOptions` from the main entry. Both are referenced by already-exported types (`McpServerPluginOptions.flexsearch`, the config union) and by the `loadIndexer`/`loadSearchProvider` signatures, but weren't exported — so a consumer couldn't name them when constructing a config.

### Docs accuracy
- **README Features** no longer claims "pre-built adapters for Vercel, Netlify, and Cloudflare Workers" — there's one web-standard `createWebRequestHandler` plus a Node dev server. CORS bullet reworded to match.
- **README props table**: `serverUrl`/`serverName` are optional (they fall back to the plugin's global data), not required.
- **CONTRIBUTING**: `src/adapters/` description updated to the current handlers.
- **SKILL**: note that `dist/` is a build artifact (run `npm run build`, or read `src`).

### Release hardening
- `prepublishOnly` now runs `lint && typecheck && test && build` so a publish can't ship type/test regressions.

### Tests
- Add `tests/public-exports-test.ts` covering `mcpServerPlugin`, `DEFAULT_PLUGIN_OPTIONS`, the tool definitions, and `createNodeHandler` — exported but previously untested (+5 tests, 109 total).

## Verification
build, lint, typecheck, 109 unit tests, snippet sync, and `npm audit --omit=dev` (0 prod vulnerabilities) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)